### PR TITLE
Add "parent_class" option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -147,3 +147,37 @@ with_mocked_tables do |m|
   end
 end
 ```
+
+#### Using a custom parent class
+
+If you need to test a base class that is not ActiveRecord::Base,
+you can do so by specifying the `parent_class` method.
+
+This is useful if your code base uses a custom base class that
+derives from ActiveRecord::Base, like so:
+
+```ruby
+
+class MyBase < ActiveRecord::Base
+  self.abstract_class = true
+  def a_custom_method
+    42
+  end
+end
+
+with_mocked_tables do |m|
+  m.create_table migration_arguments do |t|
+    t.parent_class :MyBase
+    t.model_name :Foo
+    t.layout do |l|
+      l.text :foo_text
+    end
+  end
+
+  f = Foo.new
+  f.is_a?(MyBase)   # <= true
+  f.a_custom_method # <= 42
+end
+
+
+```

--- a/lib/active_record_mocks/mock/table.rb
+++ b/lib/active_record_mocks/mock/table.rb
@@ -13,6 +13,7 @@ module ActiveRecordMocks
         @args = args
         @layout = nil
         @model_name = nil
+        @parent_class = nil
       end
 
       # ---------------------------------------------------------------
@@ -92,6 +93,19 @@ module ActiveRecordMocks
         end
       end
 
+      # ---------------------------------------------------------------
+      # Allows the setting of or setup of and returning of the name
+      # of the parent class. If this is not customized it will
+      # default to ActiveRecord::Base
+      # ---------------------------------------------------------------
+      def parent_class(cname=nil)
+        if setup? || (! cname && @parent_class)
+          @parent_class
+        else
+          @parent_class = cname ? cname.to_s.constantize : ActiveRecord::Base
+        end
+      end
+
       def setup_mocking!
         if ! setup?
           setup_table!
@@ -114,7 +128,7 @@ module ActiveRecordMocks
       private
       def setup_model!
         Object.const_set(model_name,
-            Class.new(ActiveRecord::Base)).tap do |o|
+            Class.new(parent_class)).tap do |o|
           o.table_name = table_name
           setup_includes(o)
           run_model_methods(o)

--- a/spec/lib/active_record_mocks_spec.rb
+++ b/spec/lib/active_record_mocks_spec.rb
@@ -136,4 +136,17 @@ describe ActiveRecordMocks do
       expect(t2.reflections[:foo].macro).to eq :belongs_to
     end
   end
+
+  it "creates a module using specified parent class" do
+    class TestBase < ActiveRecord::Base;  end
+    with_mocked_tables do |m|
+      t1 = m.create_table do |t|
+        t.parent_class :TestBase
+        t.has_many :bars
+        t.model_name :Foo
+      end
+      expect(t1.new).to be_a TestBase
+    end
+  end
+
 end


### PR DESCRIPTION
My codebase uses a custom base table which all my model's
inherit from.  This works, well except when I need to create
tables using active_record_mocks.

Since the created classes directly inherit from ActiveRecord::Base
and thus lack my custom methods, they don't test the same.
