### PR TITLE
Update version requirements to support ActiveRecord 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 rvm:
-  - 2.0
-  - 2.1
   - 2.2
+  - 2.3
 notifications:
   recipients:
     - jordon@envygeeks.io

--- a/active_record_mocks.gemspec
+++ b/active_record_mocks.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.authors = "Jordon Bedwell"
 
-  spec.add_dependency("activerecord", ">= 3.2", "< 4.3")
+  spec.add_dependency("activerecord", ">= 4.1", "<= 5.1")
   spec.add_development_dependency("envygeeks-coveralls", "~> 1.0")
   spec.add_development_dependency("luna-rspec-formatters", "~> 3.3")
   spec.add_development_dependency("rspec", "~> 3.3")

--- a/rspec-active_record_mocks.gemspec
+++ b/rspec-active_record_mocks.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.authors = "Jordon Bedwell"
 
-  spec.add_dependency("activerecord", ">= 3.2", "< 4.3")
+  spec.add_dependency("activerecord", ">= 4.1", "<= 5.1")
   spec.add_development_dependency("envygeeks-coveralls", "~> 1.0")
   spec.add_development_dependency("luna-rspec-formatters", "~> 3.3")
   spec.add_development_dependency("rspec", "~> 3.3")

--- a/spec/lib/active_record_mocks_spec.rb
+++ b/spec/lib/active_record_mocks_spec.rb
@@ -1,4 +1,5 @@
 require "rspec/helper"
+require 'io/console'
 
 describe ActiveRecordMocks do
   subject(:ar_connection) do


### PR DESCRIPTION
This is pretty untested by real code, but the specs all pass for me.

I had to add the `require 'io/console'` to specs otherwise I got `IO.console` not defined errors.
